### PR TITLE
Django Upgrade to 2.2 -  changes

### DIFF
--- a/subui/step.py
+++ b/subui/step.py
@@ -5,7 +5,7 @@ import unittest
 from collections import OrderedDict
 
 import six
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import override_settings
 
 from .validators import BaseValidator

--- a/subui/validators.py
+++ b/subui/validators.py
@@ -2,7 +2,7 @@ from __future__ import print_function, unicode_literals
 import inspect
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import Resolver404, resolve
+from django.urls import Resolver404, resolve
 from django.template.response import SimpleTemplateResponse
 from six.moves.urllib_parse import urlsplit, urlunsplit
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import mock
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import Resolver404
+from django.urls import Resolver404
 from django.http.response import HttpResponse
 from django.template.response import SimpleTemplateResponse
 


### PR DESCRIPTION
- Adding the changes for Django 2.2 
- Importing from django.core.urlresolvers is deprecated in favor of django.urls 

_Note - no change needed in the requirements.txt files as django is unpinned_